### PR TITLE
Use jar file instead of class files to fix the issue that "messages.properties" cannot be found.

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -10,7 +10,7 @@ export JAVAC=$CF/checker/bin/javac
 export PICO=$(cd $(dirname "$0") && pwd)
 
 # Dependencies
-export CLASSPATH=$PICO/build/classes/java/main:$CFI/dist/checker-framework-inference.jar
+export CLASSPATH=$PICO/build/libs/immutability.jar:$CFI/dist/checker-framework-inference.jar
 
 # Command
 DEBUG=""

--- a/check.sh
+++ b/check.sh
@@ -10,7 +10,8 @@ export JAVAC=$CF/checker/bin/javac
 export PICO=$(cd $(dirname "$0") && pwd)
 
 # Dependencies
-export CLASSPATH=$PICO/build/libs/immutability.jar:$CFI/dist/checker-framework-inference.jar
+export CLASSPATH=$PICO/build/classes/java/main:$PICO/build/resources/main:\
+$PICO/build/libs/immutability.jar:$CFI/dist/checker-framework-inference.jar
 
 # Command
 DEBUG=""
@@ -35,9 +36,9 @@ done
 cmd=""
 
 if [ "$DEBUG" == "" ]; then
-	cmd="$JAVAC -cp "${CLASSPATH}" -processor "${CHECKER}" "${ARGS[@]}""
+    cmd="$JAVAC -cp "${CLASSPATH}" -processor "${CHECKER}" "${ARGS[@]}""
 else
-	cmd="$JAVAC "$DEBUG" -cp "${CLASSPATH}" -processor "${CHECKER}" -AatfDoNotCache "${ARGS[@]}""
+    cmd="$JAVAC "$DEBUG" -cp "${CLASSPATH}" -processor "${CHECKER}" -AatfDoNotCache "${ARGS[@]}""
 fi
 
 eval "$cmd"


### PR DESCRIPTION
This PR resolves that when using `check.sh` to run immutability checker, the "messages.properties" for `PICOChecker` cannot be found by `cls.getResourceAsStream(filePath)`.

Former output:
`
testinput/typecheck/AssignableExample.java:35: error: [illegal.field.write] (illegal.field.write)
`

Now it looks like:
`
testinput/typecheck/AssignableExample.java:22: error: [illegal.field.write] Cannot write field via receiver: @Initialized @Immutable AssignableExample
`