### PR TITLE
Check super constructor call

### DIFF
--- a/src/main/java/pico/inference/PICOInferenceVisitor.java
+++ b/src/main/java/pico/inference/PICOInferenceVisitor.java
@@ -642,7 +642,7 @@ public class PICOInferenceVisitor extends InferenceVisitor<PICOInferenceChecker,
                 // , otherwise it will cause inference result not typecheck
                 checker.report(
                         Result.failure(
-                                "super.constructor.invocation.incompatible", subClassConstructorReturnType, superClassConstructorReturnType), node);
+                                "super.invocation.invalid", subClassConstructorReturnType, superClassConstructorReturnType), node);
             }
         }
         super.checkMethodInvocability(method, node);

--- a/src/main/java/pico/typecheck/PICOVisitor.java
+++ b/src/main/java/pico/typecheck/PICOVisitor.java
@@ -498,7 +498,8 @@ public class PICOVisitor extends InitializationVisitor<PICOAnnotatedTypeFactory,
 
     /**
      * The invoked constructor’s return type adapted to the invoking constructor’s return type must
-     * be a supertype of the invoking constructor’s return type.
+     * be a supertype of the invoking constructor’s return type. Since InitializationChecker does not
+     * apply any type rules at here, only READONLY hierarchy is checked.
      *
      * @param superCall the super invocation, e.g., "super()"
      * @param errorKey the error key, e.g., "super.invocation.invalid"
@@ -506,8 +507,7 @@ public class PICOVisitor extends InitializationVisitor<PICOAnnotatedTypeFactory,
     @Override
     protected void checkThisOrSuperConstructorCall(
             MethodInvocationTree superCall, @CompilerMessageKey String errorKey) {
-        TreePath path = atypeFactory.getPath(superCall);
-        MethodTree enclosingMethod = TreeUtils.enclosingMethod(path);
+        MethodTree enclosingMethod = visitorState.getMethodTree();
         AnnotatedTypeMirror superType = atypeFactory.getAnnotatedType(superCall);
         AnnotatedExecutableType constructorType = atypeFactory.getAnnotatedType(enclosingMethod);
         AnnotationMirror superTypeMirror = superType.getAnnotationInHierarchy(READONLY);

--- a/src/main/java/pico/typecheck/messages.properties
+++ b/src/main/java/pico/typecheck/messages.properties
@@ -3,7 +3,6 @@ constructor.return.invalid=Invalid constructor return type: %s
 method.receiver.incompatible=Incompatible method receiver: %s
 class.bound.invalid=Invalid class bound: %s
 subclass.bound.incompatible=Incompatible subclass bound: %s
-super.constructor.invocation.incompatible=Subclass constructor: %s is not compatible with super class constructor: %s
 illegal.field.write=Cannot write field via receiver: %s
 illegal.array.write=Cannot write array via receiver: %s
 static.receiverdependantmutable.forbidden=%s is forbidden in static context

--- a/testinput/inference/inferrable/issue144/ConstructorInvocationInSubclassConstructor.java
+++ b/testinput/inference/inferrable/issue144/ConstructorInvocationInSubclassConstructor.java
@@ -15,7 +15,7 @@ public class ConstructorInvocationInSubclassConstructor {
 class SubClass extends ConstructorInvocationInSubclassConstructor {
     SubClass(Object p) {
         // Handled by PICOInferenceVisito##checkMethodInvocability
-        // :: fixable-error: (super.constructor.invocation.incompatible)
+        // :: fixable-error: (super.invocation.invalid)
         super(p);
     }
 }

--- a/testinput/typecheck/AssignableExample.java
+++ b/testinput/typecheck/AssignableExample.java
@@ -28,7 +28,7 @@ public class AssignableExample {
     }
 }
 
-// :: error: (super.constructor.invocation.incompatible)
+// :: error: (super.invocation.invalid)
 @ReceiverDependantMutable class Subclass extends AssignableExample {
     void bar(@Immutable Subclass this) {
         // :: error: (illegal.field.write)

--- a/testinput/typecheck/ReceiverTypeOutsideConstructor.java
+++ b/testinput/typecheck/ReceiverTypeOutsideConstructor.java
@@ -31,13 +31,13 @@ class A {
 
 @Immutable class AIMS extends A {}
 
-// :: error: (declaration.inconsistent.with.extends.clause)
+// :: error: (declaration.inconsistent.with.extends.clause) :: error: (super.invocation.invalid)
 @ReceiverDependantMutable class ARDMS extends A {}
 
-// :: error: (declaration.inconsistent.with.extends.clause)
+// :: error: (declaration.inconsistent.with.extends.clause) :: error: (super.invocation.invalid)
 @Mutable class AMS extends A {}
 
-// :: error: (declaration.inconsistent.with.extends.clause)
+// :: error: (declaration.inconsistent.with.extends.clause) :: error: (super.invocation.invalid)
 class AUNKS extends A {}
 
 // ReceiverDependantMutable class
@@ -68,14 +68,14 @@ class B {
 
 @Immutable class BIMS extends B {}
 
-// :: error: (super.constructor.invocation.incompatible)
+// :: error: (super.invocation.invalid)
 @ReceiverDependantMutable class BRDMS extends B {}
 
-// :: error: (super.constructor.invocation.incompatible)
+// :: error: (super.invocation.invalid)
 @Mutable class BMS extends B {}
 
 // mutable by default(TODO Does this make sense compared to defaulting to receiver-dependant-mutable?)
-// :: error: (super.constructor.invocation.incompatible)
+// :: error: (super.invocation.invalid)
 class BUNKS extends B {}
 
 // Mutable class
@@ -106,13 +106,13 @@ class C {
 // :: error: (declaration.inconsistent.with.extends.clause)
 @Immutable class CIMS extends C {}
 
-// :: error: (declaration.inconsistent.with.extends.clause)
+// :: error: (declaration.inconsistent.with.extends.clause) :: error: (super.invocation.invalid)
 @ReceiverDependantMutable class CRDMS extends C {}
 
-// :: error: (super.constructor.invocation.incompatible)
+// :: error: (super.invocation.invalid)
 @Mutable class CMS extends C {}
 
-// :: error: (super.constructor.invocation.incompatible)
+// :: error: (super.invocation.invalid)
 class CUNKS extends C {}
 
 class D {

--- a/testinput/typecheck/SuperClass.java
+++ b/testinput/typecheck/SuperClass.java
@@ -20,7 +20,7 @@ public class SuperClass{
 
 class SubClass extends SuperClass{
     @Mutable SubClass(){
-        // :: error: (super.constructor.invocation.incompatible)
+        // :: error: (super.invocation.invalid)
         super(new @Immutable Date(1L));
     }
 
@@ -33,7 +33,7 @@ class SubClass extends SuperClass{
 @ReceiverDependantMutable
 class AnotherSubClass extends SuperClass{
     @ReceiverDependantMutable AnotherSubClass(){
-        // :: error: (super.constructor.invocation.incompatible)
+        // :: error: (super.invocation.invalid)
         super(new @Immutable Date(1L));
     }
 

--- a/testinput/typecheck/SuperClass2.java
+++ b/testinput/typecheck/SuperClass2.java
@@ -35,7 +35,7 @@ public class SuperClass2{
 class SubClass2 extends SuperClass2{
     @Immutable SubClass2(){
         // This is not ok any more
-        // :: error: (super.constructor.invocation.incompatible)
+        // :: error: (super.invocation.invalid)
         super(new @Mutable Date());
     }
 }
@@ -44,7 +44,7 @@ class SubClass2 extends SuperClass2{
 class AnotherSubClass2 extends SuperClass2{
     @ReceiverDependantMutable AnotherSubClass2(){
         // This is not ok any more
-        // :: error: (super.constructor.invocation.incompatible)
+        // :: error: (super.invocation.invalid)
         super(new @Mutable Date());
     }
 }


### PR DESCRIPTION
This PR:
- Implements the super constructor call check.
- Replaces the error key `"super.constructor.invocation.incompatible"` with `"super.invocation.invalid"`.
- Tweaks test files to pass the test.