### PR TITLE
Pass testinput/typecheck/OnlyOneModifierIsUse.java

### DIFF
--- a/testinput/typecheck/OnlyOneModifierIsUse.java
+++ b/testinput/typecheck/OnlyOneModifierIsUse.java
@@ -6,8 +6,8 @@ import qual.Immutable;
 
 public class OnlyOneModifierIsUse {
 
-    // :: error: (type.invalid)
+    // :: error: (type.invalid.conflicting.annos)
     @Readonly @Immutable Object field;
-    // :: error: (type.invalid)
+    // :: error: (type.invalid.conflicting.annos)
     String @Readonly @Immutable [] array;
 }


### PR DESCRIPTION
This PR uses the right error key to pass the test.

We check that if there is more than one annotation from the same hierarchy. So `@Readonly @Immutable` is wrong. The corresponding error key is `type.invalid.conflicting.annos`, not `type.invalid`.