### PR TITLE
Remove the useless code.

### DIFF
--- a/src/main/java/pico/typecheck/PICOChecker.java
+++ b/src/main/java/pico/typecheck/PICOChecker.java
@@ -2,15 +2,10 @@ package pico.typecheck;
 
 import org.checkerframework.checker.initialization.InitializationChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
-import org.checkerframework.framework.source.SupportedOptions;
-
-import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Created by mier on 20/06/17.
  */
-@SupportedOptions({"printFbcErrors"})
 public class PICOChecker extends InitializationChecker {
 
     public PICOChecker() {

--- a/src/main/java/pico/typecheck/PICOChecker.java
+++ b/src/main/java/pico/typecheck/PICOChecker.java
@@ -27,31 +27,4 @@ public class PICOChecker extends InitializationChecker {
     protected BaseTypeVisitor<?> createSourceVisitor() {
         return new PICOVisitor(this);
     }
-
-    @Override
-    protected boolean shouldAddShutdownHook() {
-        return hasOption("printFbcErrors") || super.shouldAddShutdownHook();
-    }
-
-    @Override
-    protected void shutdownHook() {
-        super.shutdownHook();
-        if (hasOption("printFbcErrors")) {
-            printFbcViolatedMethods();
-        }
-    }
-
-    private void printFbcViolatedMethods() {
-        Set<Entry<String, Integer>> entries = ((PICOVisitor) visitor).fbcViolatedMethods.entrySet();
-        if (entries.isEmpty()) {
-            System.out.println("\n=============== Congrats! No Fbc Violations Found. ===============\n");
-        } else {
-            System.out.println("\n===================== Fbc Violations Found! ======================");
-            System.out.format("%30s%30s\n", "Method", "Violated Times");
-            for (Entry<String, Integer> e : entries) {
-                System.out.format("%30s%30s\n", e.getKey(), e.getValue());
-            }
-            System.out.println("====================================================================\n");
-        }
-    }
 }

--- a/src/main/java/pico/typecheck/PICOVisitor.java
+++ b/src/main/java/pico/typecheck/PICOVisitor.java
@@ -376,30 +376,6 @@ public class PICOVisitor extends InitializationVisitor<PICOAnnotatedTypeFactory,
     }
 
     @Override
-    public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-        super.visitMethodInvocation(node, p);
-        ParameterizedExecutableType mfuPair =
-                atypeFactory.methodFromUse(node);
-        AnnotatedExecutableType invokedMethod = mfuPair.executableType;
-        ExecutableElement invokedMethodElement = invokedMethod.getElement();
-        // Only check invocability if it's super call, as non-super call is already checked
-        // by super implementation(of course in both cases, invocability is not checked when
-        // invoking static methods)
-        if (!ElementUtils.isStatic(invokedMethodElement) && TreeUtils.isSuperCall(node)) {
-            checkMethodInvocability(invokedMethod, node);
-        }
-        return null;
-    }
-
-    private void saveFbcViolatedMethods(ExecutableElement method, String actualReceiver, String declaredReceiver) {
-        if (actualReceiver.contains("@UnderInitialization") && declaredReceiver.contains("@Initialized")) {
-            String key = ElementUtils.enclosingClass(method) + "#" + method;
-            Integer times = fbcViolatedMethods.get(key) == null ? 1 : fbcViolatedMethods.get(key) + 1;
-            fbcViolatedMethods.put(key, times);
-        }
-    }
-
-    @Override
     protected void checkFieldsInitialized(Tree blockNode, boolean staticFields, PICOStore store, List<? extends AnnotationMirror> receiverAnnotations) {
         // If a class doesn't have constructor, it cannot be initialized as @Immutable, therefore no need to check uninitialized fields
         if (TreeUtils.isClassTree(blockNode)) return;

--- a/src/main/java/pico/typecheck/PICOVisitor.java
+++ b/src/main/java/pico/typecheck/PICOVisitor.java
@@ -58,13 +58,8 @@ import com.sun.source.tree.VariableTree;
  */
 public class PICOVisitor extends InitializationVisitor<PICOAnnotatedTypeFactory, PICOValue, PICOStore> {
 
-    private final boolean shouldOutputFbcError;
-    final Map<String, Integer> fbcViolatedMethods;
-
     public PICOVisitor(BaseTypeChecker checker) {
         super(checker);
-        shouldOutputFbcError = checker.hasOption("printFbcErrors");
-        fbcViolatedMethods = shouldOutputFbcError ? new HashMap<>() : null;
     }
 
     @Override


### PR DESCRIPTION
Method `saveFbcViolatedMethods` is not used in the code.

Method `visitMethodInvocation` is unnecessary to write at here, since we check super call at other place. In addition, when it is a super call, `checkMethodInvocability(invokedMethod, node)` does nothing in `BaseTypeVisitor`.

Here is the coresponding code of `BaseTypeVisitor.checkMethodInvocability`:

```java
protected void checkMethodInvocability(
            AnnotatedExecutableType method, MethodInvocationTree node) {
        if (method.getReceiverType() == null) {
            // Static methods don't have a receiver.
            return;
        }
        if (method.getElement().getKind() == ElementKind.CONSTRUCTOR) {
            return;
        }
        // Omit the rest of the code
}
```

When it is a super call, its type must be constructor, then the method just stops.