### PR TITLE
Make CompatibilityBEI2.java pass.

### DIFF
--- a/testinput/typecheck/CompatibilityBEI2.java
+++ b/testinput/typecheck/CompatibilityBEI2.java
@@ -43,10 +43,10 @@ abstract class O implements CharSequence {}
 
 @Immutable interface ImmutableInterface<E extends @ReceiverDependantMutable Object> {}
 
-// :: error: (declaration.inconsistent.with.implements.clause)
+// :: error: (declaration.inconsistent.with.implements.clause) :: error: (type.argument.type.incompatible)
 @Mutable abstract class P implements ImmutableInterface<@Mutable Object> {}
 
 @Immutable abstract class Q implements ImmutableInterface<@Immutable Object> {}
 
-// :: error: (declaration.inconsistent.with.implements.clause)
+// :: error: (declaration.inconsistent.with.implements.clause) :: error: (type.argument.type.incompatible)
 @ReceiverDependantMutable abstract class R implements ImmutableInterface<@ReceiverDependantMutable Object> {}


### PR DESCRIPTION
This PR makes CompatibilityBEI2.java pass.

Here is my thinking:

In `@Immutable interface ImmutableInterface`, after the viewpoint adaption, the type of `Object` is `@Immutable`. 
So, `<@Mutable Object>` is incorrect (`@Mutable` is not a subtype of `@Immutable`).

Similarly, `<@ReceiverDependantMutable Object>` is incorrect (`@RDM` is not a subtype of `@Immutable`).